### PR TITLE
Pin mingw-std-threads to commit before mingw.latch.h was introduced

### DIFF
--- a/build_deps
+++ b/build_deps
@@ -43,7 +43,7 @@ fi
 if [[ "$do_clean" != 1 ]]; then
 	git submodule init mingw-std-threads && \
 	git submodule update --merge --recursive && \
-	( cd mingw-std-threads && git checkout master )
+	( cd mingw-std-threads && git checkout 6c2061b7da41d6aa1b2162ff4383ec3ece864bc6 )
 fi
 
 ( cd zlib && ./build_zlib_deps ) && \


### PR DESCRIPTION
Introduction of latch implementation breaks builds on Ubuntu LTS (at time of writing). Matches current submodule commit.